### PR TITLE
feat: Add fatal.onExit to register handler that will run before exit

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:fix": "yarn lint:node",
     "prepare-release": "yarn clean && yarn build && yarn verify",
     "release": "release-it --only-version",
-    "test:deno": "deno test --allow-env test/deno/",
+    "test:deno": "deno test --allow-env --allow-read --allow-run test/deno/",
     "test:node": "NODE_ENV=test jest --coverage",
     "test:node:ci": "NODE_ENV=test jest --coverage --runInBand --colors",
     "test:node:nocover": "NODE_ENV=test jest",

--- a/src/fatal/fatal.ts
+++ b/src/fatal/fatal.ts
@@ -4,9 +4,23 @@
 import { runtime } from "../_runtime/runtime";
 
 let shouldShowErrDetail = false;
+let onExitHandler: (() => void) | undefined;
 
+/**
+ * shouldShowErrDetail sets whether or not the `detailedError` method
+ * should be used when `exitErr` is called.
+ */
 export function showErrDetail(b: boolean): void {
   shouldShowErrDetail = b;
+}
+
+/**
+ * onExit registers a handler that will run before the process exits
+ * when either `exitErr` or `exit` is called.
+ * This is useful for performing any clean up actions before exiting.
+ */
+export function onExit(handler: (() => void) | undefined): void {
+  onExitHandler = handler;
 }
 
 /**
@@ -22,6 +36,7 @@ export function exitErr(err: error, message: string, ...optionalParams: unknown[
     console.error(`Error: ${err.error()}`);
   }
 
+  onExitHandler?.();
   runtime.exit(1);
 }
 
@@ -31,5 +46,6 @@ export function exitErr(err: error, message: string, ...optionalParams: unknown[
  */
 export function exit(message: string, ...optionalParams: unknown[]): never {
   console.error(message, ...optionalParams);
+  onExitHandler?.();
   runtime.exit(1);
 }

--- a/test/deno/errors/errors_test.ts
+++ b/test/deno/errors/errors_test.ts
@@ -75,7 +75,6 @@ Deno.test("errors.withStack: wrap error", () => {
   testing.assertEquals(err.error(), "IO Error");
 });
 
-// Fix https://github.com/cszatma/node-library/issues/240
 Deno.test("errors.withStack: error or undefined", () => {
   const err1 = undefined as error | undefined;
   const err2 = errors.newError("oops") as error | undefined;
@@ -102,7 +101,6 @@ Deno.test("errors.withMessage: wrap error", () => {
   testing.assertEquals(err.error(), "error loading config: error reading file: IO Error");
 });
 
-// Fix https://github.com/cszatma/node-library/issues/240
 Deno.test("errors.withMessage: error or undefined", () => {
   const err1 = undefined as error | undefined;
   const err2 = errors.newError("oops") as error | undefined;
@@ -131,7 +129,6 @@ Deno.test("errors.wrap: nested errors", () => {
   );
 });
 
-// Fix https://github.com/cszatma/node-library/issues/240
 Deno.test("errors.wrap: error or undefined", () => {
   const err1 = undefined as error | undefined;
   const err2 = errors.newError("oops") as error | undefined;

--- a/test/deno/fatal/fatal_test.ts
+++ b/test/deno/fatal/fatal_test.ts
@@ -1,0 +1,57 @@
+import * as testing from "../testing.ts";
+import { errors, fatal } from "../../../dist/deno/mod.ts";
+
+const envVarName = "FATAL_TEST_CHILD";
+const testPath = "test/deno/fatal/fatal_test.ts";
+
+Deno.test("fatal.exitErr: no detail", async () => {
+  // Subtest
+  if (Deno.env.get(envVarName) === "true") {
+    fatal.exitErr(errors.newError("Shoot"), "Error message");
+  }
+
+  const { code, stderrData } = await testing.runSubprocessTest(
+    "/^fatal.exitErr: no detail$/",
+    testPath,
+    {
+      [envVarName]: "true",
+    },
+  );
+
+  testing.assertStringIncludes(stderrData.toString(), "Error message\nError: Shoot\n");
+  testing.assertEquals(code, 1);
+});
+
+Deno.test("fatal.exitErr: show detail", async () => {
+  // Subtest
+  if (Deno.env.get(envVarName) === "true") {
+    fatal.showErrDetail(true);
+    fatal.exitErr(errors.newError("Shoot"), "Error message");
+  }
+
+  const { code, stderrData } = await testing.runSubprocessTest(
+    "/^fatal.exitErr: show detail$/",
+    testPath,
+    {
+      [envVarName]: "true",
+    },
+  );
+
+  // Check that the error is printed with a stack trace
+  testing.assertMatch(stderrData.toString(), /Error message\nError: Shoot\n\s+at\sfatal_test\.ts/m);
+  testing.assertEquals(code, 1);
+});
+
+Deno.test("fatal.exit", async () => {
+  // Subtest
+  if (Deno.env.get(envVarName) === "true") {
+    fatal.exit("Something went wrong");
+  }
+
+  const { code, stderrData } = await testing.runSubprocessTest("/^fatal.exit$/", testPath, {
+    [envVarName]: "true",
+  });
+
+  testing.assertStringIncludes(stderrData.toString(), "Something went wrong\n");
+  testing.assertEquals(code, 1);
+});

--- a/test/node/errors/errors.test.ts
+++ b/test/node/errors/errors.test.ts
@@ -75,7 +75,6 @@ describe("errors", () => {
     expect(err.error()).toBe("IO Error");
   });
 
-  // Fix https://github.com/cszatma/node-library/issues/240
   test("errors.withStack: error or undefined", () => {
     const err1 = undefined as error | undefined;
     const err2 = errors.newError("oops") as error | undefined;
@@ -102,7 +101,6 @@ describe("errors", () => {
     expect(err.error()).toBe("error loading config: error reading file: IO Error");
   });
 
-  // Fix https://github.com/cszatma/node-library/issues/240
   test("errors.withMessage: error or undefined", () => {
     const err1 = undefined as error | undefined;
     const err2 = errors.newError("oops") as error | undefined;
@@ -130,7 +128,6 @@ describe("errors", () => {
     );
   });
 
-  // Fix https://github.com/cszatma/node-library/issues/240
   test("errors.wrap: error or undefined", () => {
     const err1 = undefined as error | undefined;
     const err2 = errors.newError("oops") as error | undefined;


### PR DESCRIPTION
Add `fatal.onExit`. This will register a function that will be called before `runtime.exit`. This can be used to perform any necessary clean up before the process exits.

Also added deno tests for fatal. The way this is done is by using a pattern from Go for testing things like `exit`, we must run the test as a subprocess. Then the main process will check if the subprocess exited as expected.