### PR TITLE
feat!: Add io module with Reader and Writer interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * as fatal from "./fatal/mod";
 export * as fs from "./fs/mod";
 export * as hex from "./hex/mod";
 export * as http from "./http/mod";
+export * as io from "./io/mod";
 export * as log from "./log/mod";
 export * as sets from "./sets/mod";
 export * as strconv from "./strconv/mod";

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2020 Christopher Szatmary <cs@christopherszatmary.com>
+// All rights reserved. MIT License.
+
+// These interfaces were adapted from Go's io package.
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+// https://github.com/golang/go/blob/master/LICENSE
+
+import { Result } from "../global";
+import * as errors from "../errors/mod";
+
+/**
+ * eof is the error returned by `read` when no more input is available.
+ * Functions should return `eof` only to signal a graceful end of input.
+ * If the EOF occurs unexpectedly in a structured data stream,
+ * the appropriate error is either `errUnexpectedEOF` or some other error
+ * giving more detail.
+ */
+export const eof = errors.errorString("EOF");
+
+/**
+ * errUnexpectedEOF means that EOF was encountered in the
+ * middle of reading a fixed-size block or data structure.
+ */
+export const errUnexpectedEOF = errors.errorString("unexpected EOF");
+
+/* Types */
+
+/**
+ * Reader is the interface that wraps the basic `read` method.
+ * It represents any type that can be read from asynchronously.
+ *
+ * `read` reads up to `p.byteLength` bytes into `p`. It resolves to
+ * a `Result` containing either the number of bytes read (`0 <= n <= p.byteLength`)
+ * or an error encountered. Even if `read` resolves to `n < p.byteLength`,
+ * it may use all of `p` as scratch space during the call. If some data is
+ * available but not `p.byteLength bytes`, `read` conventionally resolves to what
+ * is available instead of waiting for more.
+ *
+ * When `read` encounters end-of-file condition, it resolves to `eof`.
+ *
+ * Implementations of `read` are discouraged from returning a zero byte count,
+ * except when `p.byteLength === 0`. Callers should treat a result of `0` as
+ * indicating that nothing happened; in particular it does not indicate EOF.
+ *
+ * Implementations must not retain `p`.
+ */
+export interface Reader {
+  read(p: Uint8Array): Promise<Result<number, error>>;
+}
+
+/**
+ * ReaderSync is the interface that wraps the basic `readSync` method.
+ * It represents any type that can be read from synchronously.
+ *
+ * `readSync` reads up to `p.byteLength` bytes into `p`. It returns
+ * a `Result` containing either the number of bytes read (`0 <= n <= p.byteLength`)
+ * or an error encountered. Even if `readSync` returns `n < p.byteLength`,
+ * it may use all of `p` as scratch space during the call. If some data is
+ * available but not `p.byteLength bytes`, `readSync` conventionally returns to what
+ * is available instead of waiting for more.
+ *
+ * When `readSync` encounters end-of-file condition, it returns `eof`.
+ *
+ * Implementations of `readSync` are discouraged from returning a zero byte count,
+ * except when `p.byteLength === 0`. Callers should treat a result of `0` as
+ * indicating that nothing happened; in particular it does not indicate EOF.
+ *
+ * Implementations must not retain `p`.
+ */
+export interface ReaderSync {
+  readSync(p: Uint8Array): Result<number, error>;
+}
+
+/**
+ * Writer is the interface that wraps the basic `write` method.
+ * It represents any type that can be written to asynchronously.
+ *
+ * `write` writes `p.byteLength` bytes from `p` to the underlying data stream.
+ * It resolves to a `Result` containing either the number of bytes written
+ * from `p` (`0 <= n <= p.byteLength`) or an error encountered that caused
+ * the write to stop early.
+ * `write` must return an error if it would resolve to n < p.byteLength.
+ * `write` must not modify the byte data, even temporarily.
+ * Implementations must not retain `p`.
+ */
+export interface Writer {
+  write(p: Uint8Array): Promise<Result<number, error>>;
+}
+
+/**
+ * WriterSync is the interface that wraps the basic `writeSync` method.
+ * It represents any type that can be written to synchronously.
+ *
+ * `writeSync` writes `p.byteLength` bytes from `p` to the underlying data stream.
+ * It returns a `Result` containing either the number of bytes written
+ * from `p` (`0 <= n <= p.byteLength`) or an error encountered that caused
+ * the write to stop early.
+ * `writeSync` must return an error if it would return n < p.byteLength.
+ * `writeSync` must not modify the byte data, even temporarily.
+ * Implementations must not retain `p`.
+ */
+export interface WriterSync {
+  writeSync(p: Uint8Array): Result<number, error>;
+}
+
+/**
+ * StringWriter is the interface that wraps the basic `writeString` method.
+ * It represents any type that can write strings asynchronously.
+ */
+export interface StringWriter {
+  writeString(s: string): Promise<Result<number, error>>;
+}
+
+/**
+ * StringWriterSync is the interface that wraps the basic `writeStringSync` method.
+ * It represents any type that can write strings synchronously.
+ */
+export interface StringWriterSync {
+  writeStringSync(s: string): Result<number, error>;
+}
+
+/* IO helpers */
+
+/**
+ * devNull is a `Writer` and `WriterSync` on which all write calls
+ * succeed without doing anything. It functions like `/dev/null` on Unix.
+ */
+export const devNull: Writer & WriterSync = {
+  write(p: Uint8Array): Promise<Result<number, error>> {
+    return Promise.resolve(Result.success(p.byteLength));
+  },
+  writeSync(p: Uint8Array): Result<number, error> {
+    return Result.success(p.byteLength);
+  },
+};
+
+/**
+ * writeString writes the string `s` to `w`. If `w` implements `StringWriter`, it's
+ * `writeString` method is invoked directly.
+ */
+export function writeString(w: Writer, s: string): Promise<Result<number, error>> {
+  const sw = (w as unknown) as StringWriter;
+  if (typeof sw.writeString === "function") {
+    return sw.writeString(s);
+  }
+
+  const p = new TextEncoder().encode(s);
+  return w.write(p);
+}
+
+/**
+ * writeStringSync writes the string `s` to `w`. If `w` implements `StringWriterSync`, it's
+ * `writeStringSync` method is invoked directly.
+ */
+export function writeStringSync(w: WriterSync, s: string): Result<number, error> {
+  const sw = (w as unknown) as StringWriterSync;
+  if (typeof sw.writeStringSync === "function") {
+    return sw.writeStringSync(s);
+  }
+
+  const p = new TextEncoder().encode(s);
+  return w.writeSync(p);
+}

--- a/src/io/mod.ts
+++ b/src/io/mod.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2020 Christopher Szatmary <cs@christopherszatmary.com>
+// All rights reserved. MIT License.
+
+export * from "./io";

--- a/src/log/formatter.ts
+++ b/src/log/formatter.ts
@@ -244,18 +244,18 @@ export class TextFormatter implements Formatter {
     }
 
     if (!this.#needsQuoting(str)) {
-      b.writeString(str);
+      b.writeStringSync(str);
     } else {
-      b.writeString(`"${str}"`);
+      b.writeStringSync(`"${str}"`);
     }
   };
 
   #appendKeyValue = (b: bytes.DynamicBuffer, key: string, value: unknown): void => {
     if (b.length > 0) {
-      b.writeString(" ");
+      b.writeStringSync(" ");
     }
 
-    b.writeString(`${key}=`);
+    b.writeStringSync(`${key}=`);
     this.#appendValue(b, value);
   };
 
@@ -291,16 +291,16 @@ export class TextFormatter implements Formatter {
     log.msg = log.msg.replace(/\n$/, "");
 
     if (this.disableTimestamp) {
-      b.writeString(`${colorFn(levelText)} ${log.msg}`);
+      b.writeStringSync(`${colorFn(levelText)} ${log.msg}`);
     } else if (!this.fullTimestamp) {
       const timestamp = Math.floor((log.date.getTime() - baseTimestamp.getTime()) / 1000);
-      b.writeString(`${colorFn(levelText)} [${timestamp}] ${log.msg}`);
+      b.writeStringSync(`${colorFn(levelText)} [${timestamp}] ${log.msg}`);
     } else {
-      b.writeString(`${colorFn(levelText)} [${log.date.toISOString()}] ${log.msg}`);
+      b.writeStringSync(`${colorFn(levelText)} [${log.date.toISOString()}] ${log.msg}`);
     }
 
     for (const k of keys) {
-      b.writeString(` ${colorFn(k)}=`);
+      b.writeStringSync(` ${colorFn(k)}=`);
       this.#appendValue(b, data[k]);
     }
   };
@@ -368,7 +368,7 @@ export class TextFormatter implements Formatter {
       }
     }
 
-    b.writeString("\n");
+    b.writeStringSync("\n");
     return Result.success(b.bytes());
   }
 }

--- a/targets.json
+++ b/targets.json
@@ -28,6 +28,7 @@
     "fs": "node",
     "hex": "*",
     "http": "node",
+    "io": "*",
     "log": "*",
     "sets": "*",
     "strconv": "*",

--- a/test/deno/io/io_test.ts
+++ b/test/deno/io/io_test.ts
@@ -1,0 +1,59 @@
+import * as testing from "../testing.ts";
+import { Result, bytes, io } from "../../../dist/deno/mod.ts";
+
+// Writer that doesn't implement StringWriter
+class MockWriter {
+  #buf = new bytes.DynamicBuffer();
+
+  bytes(): Uint8Array {
+    return this.#buf.bytes();
+  }
+
+  async write(p: Uint8Array): Promise<Result<number, error>> {
+    return this.#buf.write(p);
+  }
+
+  writeSync(p: Uint8Array): Result<number, error> {
+    return this.#buf.writeSync(p);
+  }
+}
+
+Deno.test("io.devNull: write", async () => {
+  const data = new Uint8Array([0x1, 0x2, 0x3]);
+  const result = await io.devNull.write(data);
+  testing.assertEquals(result.unwrap(), 3);
+});
+
+Deno.test("io.devNull: writeSync", () => {
+  const data = new Uint8Array([0x1, 0x2, 0x3]);
+  const result = io.devNull.writeSync(data);
+  testing.assertEquals(result.unwrap(), 3);
+});
+
+Deno.test("io.writeString", async () => {
+  const tests = [
+    [new MockWriter(), "hello world"],
+    [new bytes.DynamicBuffer(), "hello world"],
+  ] as const;
+
+  for (const [w, s] of tests) {
+    const result = await io.writeString(w, s);
+    const data = new TextEncoder().encode(s);
+    testing.assertEquals(result.unwrap(), data.byteLength);
+    testing.assertEquals(w.bytes(), data);
+  }
+});
+
+Deno.test("io.writeStringSync", () => {
+  const tests = [
+    [new MockWriter(), "hello world"],
+    [new bytes.DynamicBuffer(), "hello world"],
+  ] as const;
+
+  for (const [w, s] of tests) {
+    const result = io.writeStringSync(w, s);
+    const data = new TextEncoder().encode(s);
+    testing.assertEquals(result.unwrap(), data.byteLength);
+    testing.assertEquals(w.bytes(), data);
+  }
+});

--- a/test/node/io/io.test.ts
+++ b/test/node/io/io.test.ts
@@ -1,0 +1,52 @@
+import { Result, bytes, io } from "../../../src";
+
+// Writer that doesn't implement StringWriter
+class MockWriter {
+  #buf = new bytes.DynamicBuffer();
+
+  bytes(): Uint8Array {
+    return this.#buf.bytes();
+  }
+
+  async write(p: Uint8Array): Promise<Result<number, error>> {
+    return this.#buf.write(p);
+  }
+
+  writeSync(p: Uint8Array): Result<number, error> {
+    return this.#buf.writeSync(p);
+  }
+}
+
+describe("io/io.ts", () => {
+  test("io.devNull: write", async () => {
+    const data = new Uint8Array([0x1, 0x2, 0x3]);
+    const result = await io.devNull.write(data);
+    expect(result.unwrap()).toBe(3);
+  });
+
+  test("io.devNull: writeSync", () => {
+    const data = new Uint8Array([0x1, 0x2, 0x3]);
+    const result = io.devNull.writeSync(data);
+    expect(result.unwrap()).toBe(3);
+  });
+
+  test.each([
+    ["Writer", new MockWriter(), "hello world"],
+    ["StringWriter", new bytes.DynamicBuffer(), "hello world"],
+  ])("io.writeString: %s", async (_name, w, s) => {
+    const result = await io.writeString(w, s);
+    const data = new TextEncoder().encode(s);
+    expect(result.unwrap()).toBe(data.byteLength);
+    expect(w.bytes()).toEqual(data);
+  });
+
+  test.each([
+    ["WriterSync", new MockWriter(), "hello world"],
+    ["StringWriterSync", new bytes.DynamicBuffer(), "hello world"],
+  ])("io.writeStringSync: %s", (_name, w, s) => {
+    const result = io.writeStringSync(w, s);
+    const data = new TextEncoder().encode(s);
+    expect(result.unwrap()).toBe(data.byteLength);
+    expect(w.bytes()).toEqual(data);
+  });
+});


### PR DESCRIPTION
Add `io` module which implements the Reader and Writer interfaces from the Go standard library. Had to add sync variants since in JS operations must be either all sync or all async.

BREAKING CHANGE: bytes.DynamicBuffer methods have changed
to match Reader and Writer intefaces