### PR TITLE
feat: Add io.stdout and io.stderr

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,7 @@ module.exports = {
   moduleFileExtensions: ["ts", "js"],
   moduleNameMapper: {
     runtime$: "<rootDir>/src/_runtime/runtime_node.ts",
+    stdio$: "<rootDir>/src/io/stdio_node.ts",
   },
   transform: {
     "^.+\\.tsx?$": "ts-jest",

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -29,6 +29,12 @@ export const eof = errors.errorString("EOF");
  */
 export const errUnexpectedEOF = errors.errorString("unexpected EOF");
 
+/**
+ * errClosed is the error used when the underlying resource being read from
+ * or written to has been closed.
+ */
+export const errClosed = errors.errorString("io: read/write on closed resource");
+
 /* Types */
 
 /**

--- a/src/io/mod.ts
+++ b/src/io/mod.ts
@@ -2,3 +2,4 @@
 // All rights reserved. MIT License.
 
 export * from "./io";
+export * from "./stdio";

--- a/src/io/stdio.d.ts
+++ b/src/io/stdio.d.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2020 Christopher Szatmary <cs@christopherszatmary.com>
+// All rights reserved. MIT License.
+
+import { Writer, WriterSync } from "./io";
+
+export declare const stdout: Writer & WriterSync;
+export declare const stderr: Writer & WriterSync;

--- a/src/io/stdio_deno.ts
+++ b/src/io/stdio_deno.ts
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 Christopher Szatmary <cs@christopherszatmary.com>
+// All rights reserved. MIT License.
+
+import { Result } from "../global";
+import * as errors from "../errors/mod";
+import { Writer, WriterSync } from "./io";
+
+interface DenoStdWriter extends Deno.Writer, Deno.WriterSync {
+  rid: number;
+}
+
+class StdioWriter {
+  #w: DenoStdWriter;
+
+  constructor(w: DenoStdWriter) {
+    this.#w = w;
+  }
+
+  get rid(): number {
+    return this.#w.rid;
+  }
+
+  async write(p: Uint8Array): Promise<Result<number, error>> {
+    // eslint-disable-next-line no-restricted-syntax
+    try {
+      const n = await this.#w.write(p);
+      return Result.success(n);
+    } catch (e) {
+      return Result.failure(errors.fromJSError(e));
+    }
+  }
+
+  writeSync(p: Uint8Array): Result<number, error> {
+    // eslint-disable-next-line no-restricted-syntax
+    try {
+      return Result.success(this.#w.writeSync(p));
+    } catch (e) {
+      return Result.failure(errors.fromJSError(e));
+    }
+  }
+}
+
+export const stdout: Writer & WriterSync = new StdioWriter(Deno.stdout);
+export const stderr: Writer & WriterSync = new StdioWriter(Deno.stderr);

--- a/src/io/stdio_node.ts
+++ b/src/io/stdio_node.ts
@@ -1,0 +1,183 @@
+// Copyright (c) 2020 Christopher Szatmary <cs@christopherszatmary.com>
+// All rights reserved. MIT License.
+
+import { Result } from "../global";
+import * as errors from "../errors/mod";
+import { errClosed, Writer, WriterSync } from "./io";
+
+interface NodeStdWriteStream extends NodeJS.WriteStream {
+  fd: number;
+}
+
+function isWritableStreamClosed(stream: NodeJS.WriteStream): boolean {
+  return (
+    !stream.writable || stream.writableEnded || stream.writableFinished || stream.destroyed || false
+  );
+}
+
+// This is a modified version of ionode.StreamWriter that is specially tailored to standard IO streams.
+// This also prevents an import cycle.
+class StdioWriter {
+  #stream: NodeStdWriteStream;
+  #error?: Error;
+  #isClosed = false;
+
+  constructor(stream: NodeStdWriteStream) {
+    this.#stream = stream;
+    stream.on("error", this.#errorHandler);
+  }
+
+  get fd(): number {
+    return this.#stream.fd;
+  }
+
+  #errorHandler = (e: Error): void => {
+    this.#error = e;
+  };
+
+  #write = (chunk: Uint8Array | string): Promise<Result<number, error>> => {
+    return new Promise((resolve) => {
+      if (this.#error !== undefined) {
+        const err = errors.fromJSError(this.#error);
+        this.#error = undefined;
+        resolve(Result.failure(err));
+        return;
+      }
+
+      // No straightforward way to test this
+      /* istanbul ignore next */
+      if (this.#isClosed || isWritableStreamClosed(this.#stream)) {
+        this.#isClosed = true;
+        resolve(Result.failure(errClosed));
+        return;
+      }
+
+      let errorOccurred = false;
+      const writeErrorHandler = (e: Error): void => {
+        this.#error = undefined;
+        errorOccurred = true;
+        const err = errors.fromJSError(e);
+        resolve(Result.failure(err));
+      };
+
+      this.#stream.once("error", writeErrorHandler);
+
+      let length: number;
+      let ok: boolean;
+      if (typeof chunk === "string") {
+        length = Buffer.byteLength(chunk, "utf-8");
+        ok = this.#stream.write(chunk, "utf-8");
+      } else {
+        length = chunk.byteLength;
+        ok = this.#stream.write(chunk);
+      }
+
+      this.#stream.removeListener("error", writeErrorHandler);
+
+      // If an error occurred return since resolve has already been called
+      // with the error
+      if (errorOccurred) {
+        return;
+      }
+
+      // Easy case, no backpressure
+      if (ok) {
+        resolve(Result.success(length));
+        return;
+      }
+
+      // Handle backpressure, wait until drained
+      // Also handle any other events that could occur, in case
+      // the stream is closed somehow
+
+      /* eslint-disable @typescript-eslint/no-use-before-define */
+      const closeHandler = (): void => {
+        removeListeners();
+        this.#isClosed = true;
+        resolve(Result.success(length));
+      };
+
+      const drainHandler = (): void => {
+        removeListeners();
+        resolve(Result.success(length));
+      };
+
+      const errorHandler = (e: Error): void => {
+        removeListeners();
+        this.#error = undefined;
+        const err = errors.fromJSError(e);
+        resolve(Result.failure(err));
+      };
+      /* eslint-enable @typescript-eslint/no-use-before-define */
+
+      const removeListeners = (): void => {
+        this.#stream.removeListener("close", closeHandler);
+        this.#stream.removeListener("drain", drainHandler);
+        this.#stream.removeListener("error", errorHandler);
+      };
+
+      this.#stream.on("close", closeHandler);
+      this.#stream.on("drain", drainHandler);
+      this.#stream.on("error", errorHandler);
+    });
+  };
+
+  #writeSync = (chunk: Uint8Array | string): Result<number, error> => {
+    if (this.#error !== undefined) {
+      const err = errors.fromJSError(this.#error);
+      this.#error = undefined;
+      return Result.failure(err);
+    }
+
+    // Just to be safe
+    /* istanbul ignore next */
+    if (this.#isClosed || isWritableStreamClosed(this.#stream)) {
+      this.#isClosed = true;
+      return Result.failure(errClosed);
+    }
+
+    let writeError: Error | undefined;
+    const writeErrorHandler = (e: Error): void => {
+      this.#error = undefined;
+      writeError = e;
+    };
+
+    this.#stream.once("error", writeErrorHandler);
+
+    let length: number;
+    if (typeof chunk === "string") {
+      length = Buffer.byteLength(chunk, "utf-8");
+      this.#stream.write(chunk, "utf-8");
+    } else {
+      length = chunk.byteLength;
+      this.#stream.write(chunk);
+    }
+
+    this.#stream.removeListener("error", writeErrorHandler);
+    if (writeError !== undefined) {
+      const err = errors.fromJSError(writeError);
+      return Result.failure(err);
+    }
+
+    return Result.success(length);
+  };
+
+  write(p: Uint8Array): Promise<Result<number, error>> {
+    return this.#write(p);
+  }
+
+  writeString(s: string): Promise<Result<number, error>> {
+    return this.#write(s);
+  }
+
+  writeSync(p: Uint8Array): Result<number, error> {
+    return this.#writeSync(p);
+  }
+
+  writeStringSync(s: string): Result<number, error> {
+    return this.#writeSync(s);
+  }
+}
+
+export const stdout: Writer & WriterSync = new StdioWriter(process.stdout);
+export const stderr: Writer & WriterSync = new StdioWriter(process.stderr);

--- a/src/ionode/stream.ts
+++ b/src/ionode/stream.ts
@@ -5,8 +5,6 @@ import { Result } from "../global";
 import * as errors from "../errors/mod";
 import * as io from "../io/mod";
 
-export const errStreamClosed = errors.errorString("ionode: stream closed");
-
 export interface ReadableStream extends NodeJS.ReadableStream {
   readonly readableEncoding?: BufferEncoding | null;
   readonly readableEnded?: boolean;
@@ -155,7 +153,7 @@ export class StreamWriter {
 
       if (this.#isClosed || isWritableStreamClosed(this.#stream)) {
         this.#isClosed = true;
-        resolve(Result.failure(errStreamClosed));
+        resolve(Result.failure(io.errClosed));
         return;
       }
 

--- a/test/deno/io/stdio_test.ts
+++ b/test/deno/io/stdio_test.ts
@@ -1,0 +1,39 @@
+import * as testing from "../testing.ts";
+import { io } from "../../../dist/deno/mod.ts";
+
+const envVarName = "IO_STDIO_TEST_CHILD";
+const testPath = "test/deno/io/stdio_test.ts";
+
+Deno.test("io: stdio: rid", () => {
+  const stdout = (io.stdout as unknown) as { rid: number };
+  const stderr = (io.stderr as unknown) as { rid: number };
+  testing.assertEquals(stdout.rid, 1);
+  testing.assertEquals(stderr.rid, 2);
+});
+
+Deno.test("io: stdio", async () => {
+  // Subtest
+  if (Deno.env.get(envVarName) === "true") {
+    let r = await io.writeString(io.stdout, "write\n");
+    r.unwrap();
+    r = await io.writeString(io.stderr, "write\n");
+    r.unwrap();
+    r = io.writeStringSync(io.stdout, "writeSync\n");
+    r.unwrap();
+    r = io.writeStringSync(io.stderr, "writeSync\n");
+    r.unwrap();
+    return;
+  }
+
+  const { code, stdoutData, stderrData } = await testing.runSubprocessTest(
+    "/^io: stdio$/",
+    testPath,
+    {
+      [envVarName]: "true",
+    },
+  );
+
+  testing.assertEquals(code, 0);
+  testing.assertStringIncludes(stdoutData.toString(), "write\nwriteSync\n");
+  testing.assertStringIncludes(stderrData.toString(), "write\nwriteSync\n");
+});

--- a/test/deno/testing.ts
+++ b/test/deno/testing.ts
@@ -44,6 +44,7 @@ export function assertPanics<T = void>(fn: () => T, msgIncludes = "", msg = ""):
 
 export interface SubprocessTestResult {
   code: number;
+  stdoutData: bytes.DynamicBuffer;
   stderrData: bytes.DynamicBuffer;
 }
 
@@ -69,15 +70,18 @@ export async function runSubprocessTest(
       ...Deno.env.toObject(),
       ...env,
     },
+    stdout: "piped",
     stderr: "piped",
   });
 
   const { code } = await p.status();
+  const stdoutData = await p.output();
   const stderrData = await p.stderrOutput();
   p.close();
 
   return {
     code,
+    stdoutData: new bytes.DynamicBuffer(stdoutData),
     stderrData: new bytes.DynamicBuffer(stderrData),
   };
 }

--- a/test/node/io/stdio.test.ts
+++ b/test/node/io/stdio.test.ts
@@ -1,0 +1,117 @@
+import { bytes, io } from "../../../src";
+
+class MockStdio {
+  #originalWrite: NodeJS.WritableStream["write"];
+  stream: NodeJS.WritableStream;
+  data: Buffer[] = [];
+
+  constructor(stream: NodeJS.WritableStream) {
+    this.#originalWrite = stream.write;
+    this.stream = stream;
+    this.stream.write = this.#write;
+  }
+
+  #write = (
+    chunk: Buffer | string,
+    encodingOrCb?: BufferEncoding | ((err?: Error | null) => void),
+    cb?: (err?: Error | null) => void,
+  ): boolean => {
+    if (typeof chunk === "string") {
+      let encoding: BufferEncoding | undefined;
+      if (typeof encodingOrCb === "string") {
+        encoding = encodingOrCb;
+      }
+
+      this.data.push(Buffer.from(chunk, encoding));
+    } else {
+      this.data.push(chunk);
+    }
+
+    if (typeof encodingOrCb === "function") {
+      encodingOrCb();
+    } else if (typeof cb === "function") {
+      cb();
+    }
+
+    return true;
+  };
+
+  restore(): void {
+    this.stream.write = this.#originalWrite;
+  }
+}
+
+describe("io/io.ts", () => {
+  test("io: stdio: fd", () => {
+    const stdout = (io.stdout as unknown) as { fd: number };
+    const stderr = (io.stderr as unknown) as { fd: number };
+    expect(stdout.fd).toBe(1);
+    expect(stderr.fd).toBe(2);
+  });
+
+  test("io: stdio: write", async () => {
+    const mockStdout = new MockStdio(process.stdout);
+    const mockStderr = new MockStdio(process.stderr);
+
+    const data = new Uint8Array([0x61, 0x62, 0x63]);
+    const resultStdout = await io.stdout.write(data);
+    const resultStderr = await io.stderr.write(data);
+
+    mockStdout.restore();
+    mockStderr.restore();
+
+    expect(resultStdout.unwrap()).toBe(3);
+    expect(resultStderr.unwrap()).toBe(3);
+    expect(bytes.equal(mockStdout.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+    expect(bytes.equal(mockStderr.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+  });
+
+  test("io: stdio: writeSync", () => {
+    const mockStdout = new MockStdio(process.stdout);
+    const mockStderr = new MockStdio(process.stderr);
+
+    const data = new Uint8Array([0x61, 0x62, 0x63]);
+    const resultStdout = io.stdout.writeSync(data);
+    const resultStderr = io.stderr.writeSync(data);
+
+    mockStdout.restore();
+    mockStderr.restore();
+
+    expect(resultStdout.unwrap()).toBe(3);
+    expect(resultStderr.unwrap()).toBe(3);
+    expect(bytes.equal(mockStdout.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+    expect(bytes.equal(mockStderr.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+  });
+
+  test("io: stdio: writeString", async () => {
+    const mockStdout = new MockStdio(process.stdout);
+    const mockStderr = new MockStdio(process.stderr);
+
+    const resultStdout = await io.writeString(io.stdout, "abc");
+    const resultStderr = await io.writeString(io.stderr, "abc");
+
+    mockStdout.restore();
+    mockStderr.restore();
+
+    expect(resultStdout.unwrap()).toBe(3);
+    expect(resultStderr.unwrap()).toBe(3);
+    expect(bytes.equal(mockStdout.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+    expect(bytes.equal(mockStderr.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+  });
+
+  test("io: stdio: writeStringSync", () => {
+    const mockStdout = new MockStdio(process.stdout);
+    const mockStderr = new MockStdio(process.stderr);
+
+    const resultStdout = io.writeStringSync(io.stdout, "abc");
+    const resultStderr = io.writeStringSync(io.stderr, "abc");
+
+    mockStdout.restore();
+    mockStderr.restore();
+
+    expect(resultStdout.unwrap()).toBe(3);
+    expect(resultStderr.unwrap()).toBe(3);
+    expect(bytes.equal(mockStdout.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+    expect(bytes.equal(mockStderr.data[0], new Uint8Array([0x61, 0x62, 0x63]))).toBe(true);
+  });
+});

--- a/test/node/ionode/stream.test.ts
+++ b/test/node/ionode/stream.test.ts
@@ -151,7 +151,7 @@ describe("ionode/stream.ts", () => {
     await w.end();
     const res = await w.write(new Uint8Array([0x32, 0x33, 0x34]));
 
-    expect(res.unwrapFailure()).toBe(ionode.errStreamClosed);
+    expect(res.unwrapFailure()).toBe(io.errClosed);
     expect(chunks).toEqual([]);
   });
 
@@ -166,7 +166,7 @@ describe("ionode/stream.ts", () => {
     mockStream.end();
     const res = await w.write(new Uint8Array([0x32, 0x33, 0x34]));
 
-    expect(res.unwrapFailure()).toBe(ionode.errStreamClosed);
+    expect(res.unwrapFailure()).toBe(io.errClosed);
     expect(chunks).toEqual([]);
   });
 


### PR DESCRIPTION
Add `io.stdout` and `io.stderr` which are wrappers over `stdout` and `stderr` that implement `io.Writer` and `io.WriterSync`. These have target specific implementations.