### PR TITLE
feat: Use io.WriterSync for log

### DIFF
--- a/src/_runtime/runtime.d.ts
+++ b/src/_runtime/runtime.d.ts
@@ -23,10 +23,6 @@ interface InspectOptions {
   getters?: boolean;
 }
 
-interface Writable {
-  write(buffer: Uint8Array): void;
-}
-
 export interface Runtime {
   readonly build: {
     os: string;
@@ -34,7 +30,6 @@ export interface Runtime {
   readonly customInspect: unique symbol;
   readonly env: Env;
   readonly noColor: boolean;
-  readonly stderr: Writable;
   exit(code?: number): never;
   inspect(value: unknown, options?: InspectOptions): string;
   isatty(rid: number): boolean;

--- a/src/_runtime/runtime_node.ts
+++ b/src/_runtime/runtime_node.ts
@@ -31,7 +31,6 @@ export const runtime: Runtime = {
   customInspect: inspect.custom as any,
   env,
   noColor: process.env.NO_COLOR !== undefined,
-  stderr: process.stderr,
   exit: process.exit,
   // TS doesn't like the inspect has multiple signatures
   // The interface required is a subset of what inspect offers so this is fine

--- a/src/log/formatter.ts
+++ b/src/log/formatter.ts
@@ -54,7 +54,7 @@ function prefixFieldClashes(data: Fields, fieldMap: Map<string, string>): void {
 }
 
 /** A `Formatter` that formats logs as `JSON`. */
-export class JSONFormatter implements Formatter {
+export class JSONFormatter {
   #textEncoder = new TextEncoder();
   disableTimestamp: boolean;
   /** Allows for putting the log fields into a nested dictionary using this key. */
@@ -121,7 +121,7 @@ export class JSONFormatter implements Formatter {
 const baseTimestamp = new Date();
 
 /** A `Formatter` that formats logs as text. */
-export class TextFormatter implements Formatter {
+export class TextFormatter {
   #isTerminal = false;
   #initCalled = false;
   #levelTextMaxLength = 0;

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -3,6 +3,7 @@
 
 import { Result } from "../global";
 import * as errors from "../errors/mod";
+import * as io from "../io/mod";
 
 /** The available log levels for a logger. */
 export enum Level {
@@ -31,21 +32,13 @@ export interface Logger {
   error(msg: string, fields?: Fields): void;
 }
 
-/**
- * Represents a type that can be written to.
- * Generally implemented by a Stream or Buffer.
- */
-export interface Writable {
-  write(buffer: Uint8Array): void;
-}
-
 /** Represents a log created by a logger. */
 export interface Log {
   data: Fields;
   date: Date;
   level: Level;
   msg: string;
-  out?: Writable;
+  out?: io.WriterSync;
 }
 
 /** Returns a string representation of the given log level. */

--- a/test/node/http/cookie.test.ts
+++ b/test/node/http/cookie.test.ts
@@ -5,8 +5,10 @@
 import { bytes, http, log } from "../../../src";
 
 describe("http/cookie.ts", () => {
+  const logOut = log.std.out;
+
   afterEach(() => {
-    log.std.out = process.stderr;
+    log.std.out = logOut;
   });
 
   test.each([


### PR DESCRIPTION
BREAKING CHANGE: StandardLogger.out and Log.out are now an io.WriterSync