### PR TITLE
feat!: Improve env API

### DIFF
--- a/src/_runtime/runtime.d.ts
+++ b/src/_runtime/runtime.d.ts
@@ -12,6 +12,7 @@ interface Env {
   get(key: string): string | undefined;
   set(key: string, value: string): void;
   delete(key: string): void;
+  toObject(): Record<string, string>;
 }
 
 interface InspectOptions {

--- a/src/_runtime/runtime_node.ts
+++ b/src/_runtime/runtime_node.ts
@@ -19,6 +19,10 @@ const env = {
   delete(key: string): void {
     delete process.env[key];
   },
+  toObject(): Record<string, string> {
+    // TS is complaining that the values should be `string | undefined`
+    return process.env as Record<string, string>;
+  },
 };
 
 export const runtime: Runtime = {

--- a/src/env/env.ts
+++ b/src/env/env.ts
@@ -5,33 +5,39 @@ import { runtime } from "../_runtime/runtime";
 import { panic } from "../global";
 
 /**
- * Checks if the given environment variable is set.
- *
- * **NOTE:** Empty values are considered set.
- */
-export function isEnvSet(name: string): boolean {
-  // If an env is not set it will be `undefined` in JS world
-  return runtime.env.get(name) !== undefined;
-}
-
-/**
- * Gets the value of the environment variable or returns `defaultValue`
+ * get retrieves the value of the environment variable or returns `defaultValue`
  * if it isn't set.
  * @param defaultValue The value to return if the environment variable is not set.
  * Defaults to `""`.
  */
-export function getEnv(name: string, defaultValue = ""): string {
-  return runtime.env.get(name) ?? defaultValue;
+export function get(key: string, defaultValue = ""): string {
+  return runtime.env.get(key) ?? defaultValue;
 }
 
-/** Sets an environment variable to the given value. */
-export function setEnv(name: string, value: string): void {
+/**
+ * lookup retrieves the value of the environment variable.
+ * If the variable is present in the environment, the value
+ * (which may be empty) is returned.
+ * Otherwise, `undefined` is returned.
+ */
+export function lookup(key: string): string | undefined {
+  return runtime.env.get(key);
+}
+
+/** set sets an environment variable to the given value. */
+export function set(name: string, value: string): void {
   runtime.env.set(name, value);
 }
 
-/** Unsets the given environment variable. */
-export function unsetEnv(name: string): void {
+/** unset unsets the given environment variable. */
+export function unset(name: string): void {
   runtime.env.delete(name);
+}
+
+/** getAll returns all environment variables as a map. */
+export function getAll(): Map<string, string> {
+  const o = runtime.env.toObject();
+  return new Map(Object.entries(o));
 }
 
 /**
@@ -41,11 +47,144 @@ export function unsetEnv(name: string): void {
 export function requireKeys(...keys: string[]): void {
   const missing: string[] = [];
   for (const k of keys) {
-    if (!isEnvSet(k)) {
+    if (lookup(k) === undefined) {
       missing.push(k);
     }
   }
   if (missing.length > 0) {
     panic(`required env vars missing: ${missing.join(", ")}`);
   }
+}
+
+const shellSpecialVarSet = new Set([
+  "*",
+  "#",
+  "$",
+  "@",
+  "!",
+  "?",
+  "-",
+  "0",
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+]);
+
+/** isAlphaNum reports whether the byte is an ASCII letter, number, or underscore */
+function isAlphaNum(c: string): boolean {
+  return c === "_" || (c >= "0" && c <= "9") || (c >= "a" && c <= "z") || (c >= "A" && c <= "Z");
+}
+
+/**
+ * getShellName returns the name that begins the string and the number of bytes
+ * consumed to extract it. If the name is enclosed in {}, it's part of a ${}
+ * expansion and two more bytes are needed than the length of the name.
+ */
+function getShellName(s: string): [string, number] {
+  if (s[0] === "{") {
+    if (s.length > 2 && shellSpecialVarSet.has(s[1]) && s[2] === "}") {
+      return [s.slice(1, 2), 3];
+    }
+    // Scan to closing brace
+    for (let i = 1; i < s.length; i++) {
+      if (s[i] === "}") {
+        if (i === 1) {
+          return ["", 2]; // Bad syntax; eat "${}"
+        }
+        return [s.slice(1, i), i + 1];
+      }
+    }
+    return ["", 1]; // Bad syntax; eat "${"
+  } else if (shellSpecialVarSet.has(s[0])) {
+    return [s.slice(0, 1), 1];
+  }
+  // Scan alphanumerics.
+  let i: number;
+  for (i = 0; i < s.length; i++) {
+    if (!isAlphaNum(s[i])) {
+      break;
+    }
+  }
+  return [s.slice(0, i), i];
+}
+
+/** expand replaces `${var}` or `$var` in the string based on the mapping function. */
+export function expand(s: string, mapping: (key: string) => string): string {
+  // ${} is all ASCII, so bytes are fine for this operation.
+  const buf: string[] = [];
+  let i = 0;
+  for (let j = 0; j < s.length; j++) {
+    if (s[j] !== "$" || j + 1 >= s.length) {
+      continue;
+    }
+
+    buf.push(s.slice(i, j));
+    const [name, w] = getShellName(s.slice(j + 1));
+    if (name === "" && w > 0) {
+      // Encountered invalid syntax; eat the
+      // characters.
+    } else if (name === "") {
+      // Valid syntax, but $ was not followed by a
+      // name. Leave the dollar character untouched.
+      buf.push(s[j]);
+    } else {
+      buf.push(mapping(name));
+    }
+
+    j += w;
+    i = j + 1;
+  }
+  if (buf.length === 0) {
+    return s;
+  }
+  return buf.join("") + s.slice(i);
+}
+
+const doubleQuoteSpecialChars = new Set(["\\", "\n", "\r", '"', "!", "$", "`"]);
+
+/**
+ * escapeValue escapes any special characters in the value `v`.
+ * If escaping is required, the returned value will be surrounded by double quotes.
+ */
+function escapeValue(v: string): string {
+  const buf: string[] = [];
+  let escapeNeeded = false;
+  for (const c of v) {
+    if (!doubleQuoteSpecialChars.has(c)) {
+      buf.push(c);
+      continue;
+    }
+
+    escapeNeeded = true;
+    if (c === "\n") {
+      buf.push("\\n");
+    } else if (c === "\r") {
+      buf.push("\\r");
+    } else {
+      buf.push(`\\${c}`);
+    }
+  }
+  if (!escapeNeeded) {
+    return v;
+  }
+  return `"${buf.join("")}"`;
+}
+
+/**
+ * stringify outputs the given environment map as a string of values
+ * in the form `key=value`.
+ */
+export function stringify(m: Map<string, string>): string {
+  const lines: string[] = [];
+  for (const [k, v] of m) {
+    const ev = escapeValue(v);
+    lines.push(`${k}=${ev}`);
+  }
+  return lines.sort().join("\n");
 }

--- a/test/deno/env/env_test.ts
+++ b/test/deno/env/env_test.ts
@@ -1,32 +1,36 @@
 import * as testing from "../testing.ts";
 import { env } from "../../../dist/deno/mod.ts";
 
-Deno.test("env.isEnvSet", () => {
-  const tests: [string, boolean][] = [
-    // var, expected
-    ["ISAVAR", true],
-    ["NOTAVAR", false],
-  ];
-
-  for (const [key, expected] of tests) {
-    if (expected) {
-      Deno.env.set(key, "true");
-    }
-
-    testing.assertEquals(env.isEnvSet(key), expected);
-
-    if (expected) {
-      Deno.env.delete(key);
-    }
+// A controlled set of variables for testing expand.
+function testGet(s: string): string {
+  switch (s) {
+    case "*":
+      return "all the args";
+    case "#":
+      return "NARGS";
+    case "$":
+      return "PID";
+    case "1":
+      return "ARGUMENT1";
+    case "HOME":
+      return "/usr/root";
+    case "H":
+      return "(Value of H)";
+    case "home_1":
+      return "/usr/foo";
+    case "_":
+      return "underscore";
+    default:
+      return "";
   }
-});
+}
 
-Deno.test("env.getEnv", () => {
+Deno.test("env.get", () => {
   const tests: [string, boolean, string | undefined, string][] = [
     // var, set, default, expected
-    ["ISAVAR", true, undefined, "true"],
-    ["NOTAVAR", false, undefined, ""],
-    ["NOTAVAR", false, "nope", "nope"],
+    ["STDLIB_TEST_ISAVAR", true, undefined, "true"],
+    ["STDLIB_TEST_NOTAVAR", false, undefined, ""],
+    ["STDLIB_TEST_NOTAVAR", false, "nope", "nope"],
   ];
 
   for (const [key, set, defaultValue, expected] of tests) {
@@ -34,7 +38,7 @@ Deno.test("env.getEnv", () => {
       Deno.env.set(key, expected);
     }
 
-    const got = env.getEnv(key, defaultValue);
+    const got = env.get(key, defaultValue);
     testing.assertEquals(got, expected);
 
     if (set) {
@@ -43,35 +47,108 @@ Deno.test("env.getEnv", () => {
   }
 });
 
-Deno.test("env.setEnv", () => {
-  const key = "NOT_SET";
-  testing.assertEquals(env.isEnvSet(key), false);
+Deno.test("env.lookup", () => {
+  const tests: ([string, true, string] | [string, false, undefined])[] = [
+    // var, set, expected
+    ["STDLIB_TEST_ISAVAR", true, "true"],
+    ["STDLIB_TEST_NOTAVAR", false, undefined],
+  ];
 
-  env.setEnv(key, "now it is");
-  testing.assertEquals(env.getEnv(key), "now it is");
+  for (const [key, set, expected] of tests) {
+    if (set) {
+      Deno.env.set(key, expected as string);
+    }
+
+    const got = env.lookup(key);
+    testing.assertEquals(got, expected);
+
+    if (set) {
+      Deno.env.delete(key);
+    }
+  }
+});
+
+Deno.test("env.set", () => {
+  const key = "STDLIB_TEST_NOT_SET";
+  testing.assertEquals(env.lookup(key), undefined);
+
+  env.set(key, "now it is");
+  testing.assertEquals(env.lookup(key), "now it is");
 
   Deno.env.delete(key);
 });
 
-Deno.test("env.setEnv", () => {
-  const key = "NOT_SET";
-  env.setEnv(key, "now it is");
-  testing.assertEquals(env.getEnv(key), "now it is");
+Deno.test("env.unset", () => {
+  const key = "STDLIB_TEST_NOT_SET";
+  env.set(key, "now it is");
+  testing.assertEquals(env.lookup(key), "now it is");
 
-  env.unsetEnv(key);
-  testing.assertEquals(env.isEnvSet(key), false);
+  env.unset(key);
+  testing.assertEquals(env.lookup(key), undefined);
+});
+
+Deno.test("env.getAll", () => {
+  const expected = new Map(Object.entries(Deno.env.toObject()));
+  testing.assertEquals(env.getAll(), expected);
 });
 
 Deno.test("env.requireKeys", () => {
-  env.setEnv("STDLIB_TEST_ENV_FOO", "foo");
-  env.setEnv("STDLIB_TEST_ENV_BAR", "bar");
+  env.set("STDLIB_TEST_ENV_FOO", "foo");
+  env.set("STDLIB_TEST_ENV_BAR", "bar");
   env.requireKeys("STDLIB_TEST_ENV_FOO", "STDLIB_TEST_ENV_BAR");
 });
 
 Deno.test("env.requireKeys: not set", () => {
-  env.unsetEnv("STDLIB_TEST_ENV_FOO");
-  env.unsetEnv("STDLIB_TEST_ENV_BAR");
+  env.unset("STDLIB_TEST_ENV_FOO");
+  env.unset("STDLIB_TEST_ENV_BAR");
   testing.assertPanics(() => {
     env.requireKeys("STDLIB_TEST_ENV_FOO", "STDLIB_TEST_ENV_BAR");
   }, "required env vars missing: STDLIB_TEST_ENV_FOO, STDLIB_TEST_ENV_BAR");
+});
+
+Deno.test("env.expand", () => {
+  const tests: [string, string][] = [
+    ["", ""],
+    ["$*", "all the args"],
+    ["$$", "PID"],
+    ["${*}", "all the args"],
+    ["$1", "ARGUMENT1"],
+    ["${1}", "ARGUMENT1"],
+    ["now is the time", "now is the time"],
+    ["$HOME", "/usr/root"],
+    ["$home_1", "/usr/foo"],
+    ["${HOME}", "/usr/root"],
+    ["${H}OME", "(Value of H)OME"],
+    ["A$$$#$1$H$home_1*B", "APIDNARGSARGUMENT1(Value of H)/usr/foo*B"],
+    ["start$+middle$^end$", "start$+middle$^end$"],
+    ["mixed$|bag$$$", "mixed$|bagPID$"],
+    ["$", "$"],
+    ["$}", "$}"],
+    ["${", ""], // invalid syntax; eat up the characters
+    ["${}", ""], // invalid syntax; eat up the characters
+  ];
+
+  for (const [s, expected] of tests) {
+    testing.assertEquals(env.expand(s, testGet), expected);
+  }
+});
+
+Deno.test("env.stringify", () => {
+  const m = new Map([
+    ["foo", "bar"],
+    ["baz", "123"],
+    ["HOME", "/usr/root"],
+    ["quoted", `va"lu"e`],
+    ["escape", "\n\r\\r!$"],
+  ]);
+  const s = env.stringify(m);
+
+  testing.assertEquals(
+    s,
+    `HOME=/usr/root
+baz=123
+escape="\\n\\r\\\\r\\!\\$"
+foo=bar
+quoted="va\\"lu\\"e"`,
+  );
 });

--- a/test/node/colors/colors.test.ts
+++ b/test/node/colors/colors.test.ts
@@ -3,15 +3,15 @@ import { colors, env } from "../../../src";
 describe("colors/colors.ts", () => {
   let noColor: string | undefined;
   beforeAll(() => {
-    if (env.isEnvSet("NO_COLOR")) {
-      noColor = env.getEnv("NO_COLOR");
-      env.unsetEnv("NO_COLOR");
+    noColor = env.lookup("NO_COLOR");
+    if (noColor !== undefined) {
+      env.unset("NO_COLOR");
     }
   });
 
   afterAll(() => {
     if (noColor !== undefined) {
-      env.setEnv("NO_COLOR", noColor);
+      env.set("NO_COLOR", noColor);
     }
   });
 

--- a/test/node/env/env.test.ts
+++ b/test/node/env/env.test.ts
@@ -1,33 +1,43 @@
+/* eslint-disable no-template-curly-in-string */
+
 import { env } from "../../../src";
+
+// A controlled set of variables for testing expand.
+function testGet(s: string): string {
+  switch (s) {
+    case "*":
+      return "all the args";
+    case "#":
+      return "NARGS";
+    case "$":
+      return "PID";
+    case "1":
+      return "ARGUMENT1";
+    case "HOME":
+      return "/usr/root";
+    case "H":
+      return "(Value of H)";
+    case "home_1":
+      return "/usr/foo";
+    case "_":
+      return "underscore";
+    default:
+      return "";
+  }
+}
 
 describe("env/env.ts", () => {
   test.each([
-    // var, expected
-    ["ISAVAR", true],
-    ["NOTAVAR", false],
-  ])("env.isEnvSet: %s, %s", (key, expected) => {
-    if (expected) {
-      process.env[key] = "true";
-    }
-
-    expect(env.isEnvSet(key)).toBe(expected);
-
-    if (expected) {
-      delete process.env[key];
-    }
-  });
-
-  test.each([
     // var, set, default, expected
-    ["ISAVAR", true, undefined, "true"],
-    ["NOTAVAR", false, undefined, ""],
-    ["NOTAVAR", false, "nope", "nope"],
-  ])("env.getEnv: %#", (key, set, defaultValue, expected) => {
+    ["STDLIB_TEST_ISAVAR", true, undefined, "true"],
+    ["STDLIB_TEST_NOTAVAR", false, undefined, ""],
+    ["STDLIB_TEST_NOTAVAR", false, "nope", "nope"],
+  ])("env.get: %#", (key, set, defaultValue, expected) => {
     if (set) {
       process.env[key] = expected;
     }
 
-    const got = env.getEnv(key, defaultValue);
+    const got = env.get(key, defaultValue);
     expect(got).toBe(expected);
 
     if (set) {
@@ -35,36 +45,98 @@ describe("env/env.ts", () => {
     }
   });
 
-  test("env.setEnv", () => {
-    const key = "NOT_SET";
-    expect(env.isEnvSet(key)).toBe(false);
+  test.each([
+    // var, set, expected
+    ["STDLIB_TEST_ISAVAR", true, "true"],
+    ["STDLIB_TEST_NOTAVAR", false, undefined],
+  ])("env.lookup: %#", (key, set, expected) => {
+    if (set) {
+      process.env[key] = expected;
+    }
 
-    env.setEnv(key, "now it is");
-    expect(env.getEnv(key)).toBe("now it is");
+    const got = env.lookup(key);
+    expect(got).toBe(expected);
+
+    if (set) {
+      delete process.env[key];
+    }
+  });
+
+  test("env.set", () => {
+    const key = "STDLIB_TEST_NOT_SET";
+    expect(env.lookup(key)).toBeUndefined();
+
+    env.set(key, "now it is");
+    expect(env.lookup(key)).toBe("now it is");
 
     delete process.env[key];
   });
 
-  test("env.unsetEnv", () => {
-    const key = "NOT_SET";
-    env.setEnv(key, "now it is");
-    expect(env.getEnv(key)).toBe("now it is");
+  test("env.unset", () => {
+    const key = "STDLIB_TEST_NOT_SET";
+    env.set(key, "now it is");
+    expect(env.lookup(key)).toBe("now it is");
 
-    env.unsetEnv(key);
-    expect(env.isEnvSet(key)).toBe(false);
+    env.unset(key);
+    expect(env.lookup(key)).toBeUndefined();
+  });
+
+  test("env.getAll", () => {
+    const expected = new Map(Object.entries(process.env));
+    expect(env.getAll()).toEqual(expected);
   });
 
   test("env.requireKeys", () => {
-    env.setEnv("STDLIB_TEST_ENV_FOO", "foo");
-    env.setEnv("STDLIB_TEST_ENV_BAR", "bar");
+    env.set("STDLIB_TEST_ENV_FOO", "foo");
+    env.set("STDLIB_TEST_ENV_BAR", "bar");
     env.requireKeys("STDLIB_TEST_ENV_FOO", "STDLIB_TEST_ENV_BAR");
   });
 
   test("env.requireKeys: not set", () => {
-    env.unsetEnv("STDLIB_TEST_ENV_FOO");
-    env.unsetEnv("STDLIB_TEST_ENV_BAR");
+    env.unset("STDLIB_TEST_ENV_FOO");
+    env.unset("STDLIB_TEST_ENV_BAR");
     expect(() => {
       env.requireKeys("STDLIB_TEST_ENV_FOO", "STDLIB_TEST_ENV_BAR");
     }).toPanic("required env vars missing: STDLIB_TEST_ENV_FOO, STDLIB_TEST_ENV_BAR");
+  });
+
+  test.each([
+    ["", ""],
+    ["$*", "all the args"],
+    ["$$", "PID"],
+    ["${*}", "all the args"],
+    ["$1", "ARGUMENT1"],
+    ["${1}", "ARGUMENT1"],
+    ["now is the time", "now is the time"],
+    ["$HOME", "/usr/root"],
+    ["$home_1", "/usr/foo"],
+    ["${HOME}", "/usr/root"],
+    ["${H}OME", "(Value of H)OME"],
+    ["A$$$#$1$H$home_1*B", "APIDNARGSARGUMENT1(Value of H)/usr/foo*B"],
+    ["start$+middle$^end$", "start$+middle$^end$"],
+    ["mixed$|bag$$$", "mixed$|bagPID$"],
+    ["$", "$"],
+    ["$}", "$}"],
+    ["${", ""], // invalid syntax; eat up the characters
+    ["${}", ""], // invalid syntax; eat up the characters
+  ])("env.expand: %s", (s, expected) => {
+    expect(env.expand(s, testGet)).toBe(expected);
+  });
+
+  test("env.stringify", () => {
+    const m = new Map([
+      ["foo", "bar"],
+      ["baz", "123"],
+      ["HOME", "/usr/root"],
+      ["quoted", `va"lu"e`],
+      ["escape", "\n\r\\r!$"],
+    ]);
+    const s = env.stringify(m);
+
+    expect(s).toBe(`HOME=/usr/root
+baz=123
+escape="\\n\\r\\\\r\\!\\$"
+foo=bar
+quoted="va\\"lu\\"e"`);
   });
 });


### PR DESCRIPTION
Redesigned the API for the env module and added some new functionality. env.expand() replaces variables in strings. env.stringify() turns an env map into a .env style string.

BREAKING CHANGE: env.getEnv is now env.get, env.setEnv is now env.set, env.unsetEnv is now env.unset, env.isEnvSet has been replaced with env.lookup.